### PR TITLE
Only model lakes in CASC states

### DIFF
--- a/1_prep.R
+++ b/1_prep.R
@@ -6,6 +6,11 @@ p1 <- list(
   # Pull in GLM 3 template
   tar_target(p1_glm_template_nml, '1_prep/in/glm3_template.nml', format = 'file'),
   
+  # Define vector of CASC states
+  # For now, we are only interested in modeling lakes within these states
+  tar_target(p1_CASC_states,
+             c('ND','SD','IA','MI','IN','IL','WI','MN','MO','AR','OH')),
+  
   ##### Pull in files from lake-temperature-model-prep #####
   # TODO - transfer to Denali using globus
   # list of lake-specific attributes for nml modification
@@ -17,21 +22,24 @@ p1 <- list(
   tar_target(p1_obs_feather, '1_prep/in/merged_temp_data_daily.feather', format = 'file'),
   
   # lake-to-state xwalk, filtered to only those lakes that are in nml list (able to be modeled by GLM)
+  # and only those lakes that fall within CASC states. 
   # used to define site_ids for NLDAS runs, not for GCM runs
   # file copied from lake-temperature-model-prep repo '2_crosswalk_munge/out/lake_to_state_xwalk.rds'
   tar_target(p1_lake_to_state_xwalk_rds, '1_prep/in/lake_to_state_xwalk.rds', format='file'),
   tar_target(p1_lake_to_state_xwalk_df,
              readr::read_rds(p1_lake_to_state_xwalk_rds) %>%
-               filter(site_id %in% p1_nml_site_ids) %>%
+               filter(site_id %in% p1_nml_site_ids, state %in% p1_CASC_states) %>%
                arrange(site_id)),
 
   # lake - GCM cell - GCM tile crosswalk, assumed to only include lakes
-  # that are in the nml list (able to be modeled by GLM)
+  # that are in the nml list (able to be modeled by GLM), filtered to 
+  # only those lakes that fall within CASC states
   # used to define site_ids for GCM runs
   # file copied from lake-temperature-model-prep repo '7_drivers_munge/out/lake_cell_tile_xwalk.csv'
   tar_target(p1_lake_cell_tile_xwalk_csv, '1_prep/in/lake_cell_tile_xwalk.csv', format = 'file'),
   tar_target(p1_lake_cell_tile_xwalk_df, 
              readr::read_csv(p1_lake_cell_tile_xwalk_csv, col_types=cols()) %>%
+               filter(state %in% p1_CASC_states) %>%
                arrange(site_id)),
   
   ##### GCM model set up #####

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -2,10 +2,7 @@ source('5_evaluate/src/eval_utility_fxns.R')
 source('4_visualize/src/plot_data_utility_fxns.R')
 
 p5 <- list(
-  # For now, evaluate only predictions for lakes within CASC states
-  tar_target(p5_CASC_states,
-             c('ND','SD','IA','MI','IN','IL','WI','MN','MO','AR','OH')),
-  
+
   ##### Evaluate GCM model output #####
   
   ###### Prep predictions and observations ######
@@ -14,7 +11,6 @@ p5 <- list(
   # filtering to sites withing CASC states
   tar_target(p5_gcm_export_site_ids,
              p3_gcm_glm_uncalibrated_output_feather_tibble %>%
-               filter(state %in% p5_CASC_states) %>%
                arrange(site_id) %>%
                pull(site_id) %>%
                unique()),
@@ -144,7 +140,6 @@ p5 <- list(
   # filtering to sites within CASC states
   tar_target(p5_nldas_export_site_ids,
              p3_nldas_glm_uncalibrated_output_feather_tibble %>%
-               filter(state %in% p5_CASC_states) %>%
                arrange(site_id) %>%
                pull(site_id)),
   


### PR DESCRIPTION
Modifying the `1_prep.R` phase of pipeline to only set up model runs for lakes that fall within CASC states. This change allows us to drop that restriction in the `5_evaluate.R` phase.