### PR TITLE
Add dependency to evaluation pred-obs matching

### DIFF
--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -206,7 +206,7 @@ p5 <- list(
   # Pull out lake depth for each NLDAS evaluation site
   tar_target(
     p5_nldas_eval_depths,
-    filter(p5_gcm_obs_depths, site_id %in% p5_gcm_eval_sites)
+    filter(p5_nldas_obs_depths, site_id %in% p5_nldas_eval_sites)
   ),
   
   # Prep matched preds for evaluation

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -63,6 +63,7 @@ p5 <- list(
   # map over obs_for_eval_groups (so parallelizable on Tallgrass)
   tar_target(p5_gcm_pred_obs,
              {
+               # Each branch has one site id, but must match predictions from each of the 6 GCM drivers
                tar_assert_identical(unique(p5_gcm_export_tibble_groups$site_id), unique(p5_gcm_obs_for_eval_groups$site_id),
                                     "unique p5_gcm_export_tibble_groups site id doesn't match unique p5_gcm_obs_for_eval_groups site id")
                purrr::pmap_dfr(p5_gcm_export_tibble_groups, function(...) {


### PR DESCRIPTION
This PR fixes a bug in the `5_evaluate.R` step that we had not previously identified.

### The bug

When the evaluation code was first written, we read in all GLM predictions and then filtered to only predictions for sites with observations. This was too expensive an approach at scale, so we switched to reading in the predictions [within the step to match predictions to observations](https://github.com/USGS-R/lake-temperature-process-models/blob/main/5_evaluate/src/eval_utility_fxns.R#L53). The targets call to the matching function was set up such that we [used a site id to reconstruct the export filepath](https://github.com/USGS-R/lake-temperature-process-models/blob/main/5_evaluate.R#L189). Unfortunately, with this approach, `targets` was not tracking the model output files as a dependency of the matched pred-obs target. So long as the set of sites for which we had observations and predictions didn't change, this target didn't rebuild, which meant any changed model output was not used for evaluation.

I first noticed this behavior when rebuilding the `p5_nldas` steps following a [complete re-run of the NLDAS models](https://github.com/USGS-R/lake-temperature-process-models/discussions/57#discussioncomment-3485538). Despite there being new model output for several sites, `targets` skipped the `p5_nldas_pred_obs` target. I confirmed the behavior locally by rebuilding GCM models for several sites with outdated GCM data then re-running the evaluation steps -- again, the evaluation pred-obs target (`p5_gcm_pred_obs`) didn't rebuild.

### The fix
The fix is to filter the `p3_{driver_type}_glm_uncalibrated_output_feather_tibble` [to only those sites for which we have observations and predictions](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/add_dependency_to_eval/5_evaluate.R#L194-L200), then use this filtered dataframe to [provide (and thereby track) the export filepaths for each site](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/add_dependency_to_eval/5_evaluate.R#L216-L222), or in the case of the GCM models, [for each site and GCM](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/add_dependency_to_eval/5_evaluate.R#L68-L74).

This PR also fixes a typo where `p5_nldas_eval_depths` was referencing gcm targets. This code had not impacted any builds, as it was part of [the extrapolate preds PR](https://github.com/USGS-R/lake-temperature-process-models/pull/75) and only as far as `p5_nldas_pred_obs_csv` [had been rebuilt](https://github.com/USGS-R/lake-temperature-process-models/issues/59#issuecomment-1194550488).